### PR TITLE
feat: ability to mount pre created configmaps and secrets via envFrom

### DIFF
--- a/charts/kestra/templates/_helpers.tpl
+++ b/charts/kestra/templates/_helpers.tpl
@@ -227,13 +227,23 @@ spec:
             {{- if $.Values.extraEnv }}{{ toYaml $.Values.extraEnv | trim | nindent 12 }}{{ end }}
             {{- include "kestra.configurationPath" $ | nindent 12 }}
           envFrom:
-            {{- if $.Values.extraConfigMapEnvFrom }}
+            {{- with .Values.extraConfigMapEnvFrom }}
+            {{- range . }}
             - configMapRef:
-                name: {{ $.Values.extraConfigMapEnvFrom }}
+                name: {{ .name }}
+              {{- if .prefix }}
+                prefix: {{ .prefix }}
+              {{- end }}
             {{- end }}
-            {{- if $.Values.extraSecretEnvFrom }}
+            {{- end }}
+            {{- with .Values.extraSecretEnvFrom }}
+            {{- range . }}
             - secretRef:
-                name: {{ $.Values.extraSecretEnvFrom }}
+                name: {{ .name }}
+              {{- if .prefix }}
+                prefix: {{ .prefix }}
+              {{- end }}
+            {{- end }}
             {{- end }}
           volumeMounts:
             {{- if $.Values.extraVolumeMounts }}{{ toYaml $.Values.extraVolumeMounts | trim | nindent 12 }}{{ end }}

--- a/charts/kestra/templates/_helpers.tpl
+++ b/charts/kestra/templates/_helpers.tpl
@@ -226,6 +226,15 @@ spec:
           env:
             {{- if $.Values.extraEnv }}{{ toYaml $.Values.extraEnv | trim | nindent 12 }}{{ end }}
             {{- include "kestra.configurationPath" $ | nindent 12 }}
+          envFrom:
+            {{- if $.Values.extraConfigMapEnvFrom }}
+            - configMapRef:
+                name: {{ $.Values.extraConfigMapEnvFrom }}
+            {{- end }}
+            {{- if $.Values.extraSecretEnvFrom }}
+            - secretRef:
+                name: {{ $.Values.extraSecretEnvFrom }}
+            {{- end }}
           volumeMounts:
             {{- if $.Values.extraVolumeMounts }}{{ toYaml $.Values.extraVolumeMounts | trim | nindent 12 }}{{ end }}
             {{- if $.Values.configuration }}

--- a/charts/kestra/templates/_helpers.tpl
+++ b/charts/kestra/templates/_helpers.tpl
@@ -226,7 +226,9 @@ spec:
           env:
             {{- if $.Values.extraEnv }}{{ toYaml $.Values.extraEnv | trim | nindent 12 }}{{ end }}
             {{- include "kestra.configurationPath" $ | nindent 12 }}
+          {{- if or .Values.extraConfigMapEnvFrom .Values.extraSecretEnvFrom }}
           envFrom:
+          {{- end }}
             {{- with .Values.extraConfigMapEnvFrom }}
             {{- range . }}
             - configMapRef:

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -230,10 +230,12 @@ extraEnv: []
 
 extraContainers: []
 
+
+# https://kestra.io/docs/administrator-guide/configuration/others#kestravariablesenv-vars-prefix
 extraConfigMapEnvFrom:
   # - name: my-existing-configmap-no-prefix
   # - name: my-existing-configmap-with-prefix
-  #   prefix: PREFIX_
+  #   prefix: KESTRA_
 
 extraSecretEnvFrom:
   # - name: my-existing-no-prefix

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -230,9 +230,16 @@ extraEnv: []
 
 extraContainers: []
 
-extraConfigMapEnvFrom: []
+extraConfigMapEnvFrom:
+  # - name: my-existing-configmap-no-prefix
+  # - name: my-existing-configmap-with-prefix
+  #   prefix: PREFIX_
 
-extraSecretEnvFrom: [] 
+extraSecretEnvFrom:
+  # - name: my-existing-no-prefix
+  # - name: my-existing-with-prefix
+  #   prefix: SECRET_
+
 
 podSecurityContext: {}
 # fsGroup: 2000

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -39,6 +39,7 @@ deployments:
     securityContext: {}
     terminationGracePeriodSeconds: 30
     extraContainers: []
+    extraSecretEnvFrom: asd
     autoscaler:
       enabled: false
       minReplicas: 1
@@ -74,7 +75,7 @@ deployments:
     command: "server scheduler"
 
   worker:
-    enabled: false
+    enabled: true
     kind: Deployment
     command: "server worker --thread={{ .Values.deployments.worker.workerThreads }}"
     terminationGracePeriodSeconds: 60
@@ -229,6 +230,10 @@ extraVolumes: []
 extraEnv: []
 
 extraContainers: []
+
+extraConfigMapEnvFrom: []
+
+extraSecretEnvFrom: [] 
 
 podSecurityContext: {}
 # fsGroup: 2000

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -39,7 +39,6 @@ deployments:
     securityContext: {}
     terminationGracePeriodSeconds: 30
     extraContainers: []
-    extraSecretEnvFrom: asd
     autoscaler:
       enabled: false
       minReplicas: 1
@@ -75,7 +74,7 @@ deployments:
     command: "server scheduler"
 
   worker:
-    enabled: true
+    enabled: false
     kind: Deployment
     command: "server worker --thread={{ .Values.deployments.worker.workerThreads }}"
     terminationGracePeriodSeconds: 60


### PR DESCRIPTION
### What changes are being made and why?

Added ability to use pre created configmaps or secrets for Kestra env variables for external secret controllers like sealed-secrets operator

---

### How the changes have been QAed?

Tried rendering the chart locally via
```
helm template kestra . --output-dir=./tmp
```

---


