### PR TITLE
feat(helm): add loadBalancerIP to service spec

### DIFF
--- a/charts/kestra/templates/service.yaml
+++ b/charts/kestra/templates/service.yaml
@@ -12,6 +12,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -171,6 +171,7 @@ postgresql:
 service:
   type: ClusterIP
   port: 8080
+  loadBalancerIP: ""
   annotations: {}
 
 


### PR DESCRIPTION
### What changes are being made and why?

Hi !

I'd like to add `loadBalancerIP` to service spec to allow use cases such as Internal Load Balancers on Google Kubernetes Engine with static internal IP reserved in advance.  
It helps with:
- Increasing security by not exposing the service with an external IP.
- Allowing more advanced automation in provisioning infrastructure.

See [this](https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer#load_balancer_types), [this](https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#enabling_internal_load_balancer_subsetting_in_a_new_cluster) and [this](https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer-parameters).

---

### How the changes have been QAed?

Tested on GKE v1.27.8-gke.1067004 STABLE Release Channel with the Kestra chart deployed with helmfime 0.162.0 as a local chart and these values:

```yaml
service:
  type: LoadBalancer
  loadBalancerIP: 10.42.0.30
  annotations:
    networking.gke.io/load-balancer-type: "Internal"
```

---
