### PR TITLE
feat(helm): Add loading configuration from external secret

### DIFF
--- a/charts/kestra/templates/_helpers.tpl
+++ b/charts/kestra/templates/_helpers.tpl
@@ -146,6 +146,7 @@ Env vars
   {{- if $.Values.configuration }}{{ $configurations = append $configurations "/app/confs/application.yml" }}{{- end }}
   {{- if $.Values.secrets }}{{ $configurations = append $configurations "/app/secrets/application-secrets.yml" }}{{- end }}
   {{- if include "kestra.k8s-config" $ }}{{ $configurations = append $configurations "/app/secrets/application-k8s.yml" }}{{- end }}
+  {{- if $.Values.externalSecret }}{{ $configurations = append $configurations "/app/secrets/external/application-secrets-external.yml" }}{{- end }}
 {{- end -}}
 
 - name: MICRONAUT_CONFIG_FILES
@@ -257,6 +258,11 @@ spec:
             - name: secrets
               mountPath: /app/secrets/
             {{- end }}
+            {{- if $.Values.externalSecret }}
+            - name: external-secret
+              mountPath: /app/secrets/external/
+            {{- end }}
+  
             {{- if $dind }}
             - name: docker-dind-socket
               mountPath: /dind
@@ -372,6 +378,14 @@ spec:
               - key: application-k8s.yml
                 path: application-k8s.yml
             {{- end }}
+        {{- end }}
+        {{- if $.Values.externalSecret }}
+        - name: external-secret
+          secret:
+            secretName: {{ $.Values.externalSecret.secretName }}
+            items:
+              - key: {{ $.Values.externalSecret.key }}
+                path: application-secrets-external.yml
         {{- end }}
         {{- if $dind }}
         - name: docker-dind-socket

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -14,6 +14,10 @@ configuration: {}
 ### Secrets for deployments
 secrets: {}
 
+### Load configuration from existing secret
+externalSecret: {}
+  #secretName: secret-name
+  #key: key-inside-the-secret.yml
 
 ### configuration files
 configurationPath:


### PR DESCRIPTION

### What changes are being made and why?
Add a possibility to load kestra configuration from an existing secret. This allow to hide some part of the kestra configuration in a secret not managed by the helm chart.

