### PR TITLE
feat: Allow to add deployment annotations and labels

### DIFF
--- a/charts/kestra/templates/_helpers.tpl
+++ b/charts/kestra/templates/_helpers.tpl
@@ -170,10 +170,16 @@ metadata:
   name: {{ include "kestra.fullname" $merged }}
   labels:
     {{- include "kestra.labels" $merged | nindent 4 }}
-  {{- with $.Values.annotations }}
+    {{- with $deployment.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $deployment.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if eq $deployment.kind "Deployment" }}
   replicas: {{ $deployment.replicaCount | default 1 }}

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -34,6 +34,8 @@ deployments:
     kind: Deployment
     replicaCount: 1
     command: "server webserver"
+    labels: {}
+    annotations: {}
     resources: {}
     nodeSelector: {}
     tolerations: []


### PR DESCRIPTION
### What changes are being made and why?
This PR allow user to set labels and annotations per deployment (eg webserver, worker, etc..)
```
webserver:
   ...
   labels:
      mybeautifullabel: "OK"
   annotations:
      myannotation: "Hello"

worker:
   ...
   labels:
      mybeautifullabel: "OK"
   annotations:
      myannotation: "Hello"

```