### PR TITLE
feat(helm): add support for custom exec command on deployment probes

### DIFF
--- a/charts/kestra/templates/_helpers.tpl
+++ b/charts/kestra/templates/_helpers.tpl
@@ -286,11 +286,16 @@ spec:
               protocol: TCP
           {{- if $.Values.startupProbe.enabled }}
           startupProbe:
+            {{- if $.Values.startupProbe.httpGetEnabled }}
             httpGet:
               path: {{ $.Values.startupProbe.path }}
               port: {{ $.Values.startupProbe.port }}
               {{- if $.Values.startupProbe.httpGetExtra }}{{ toYaml $.Values.startupProbe.httpGetExtra | trim | nindent 14 }}{{ end }}
             initialDelaySeconds: {{ $.Values.startupProbe.initialDelaySeconds }}
+            {{- end }}
+            {{- if $.Values.startupProbe.exec }}
+            exec: {{- toYaml $.Values.startupProbe.exec | nindent 14 }}
+            {{- end }}
             periodSeconds: {{ $.Values.startupProbe.periodSeconds }}
             timeoutSeconds: {{ $.Values.startupProbe.timeoutSeconds }}
             successThreshold: {{ $.Values.startupProbe.successThreshold }}
@@ -298,10 +303,15 @@ spec:
           {{- end }}
           {{- if $.Values.livenessProbe.enabled }}
           livenessProbe:
+            {{- if $.Values.livenessProbe.httpGetEnabled }}
             httpGet:
               path: {{ $.Values.livenessProbe.path }}
               port: {{ $.Values.livenessProbe.port }}
               {{- if $.Values.livenessProbe.httpGetExtra }}{{ toYaml $.Values.livenessProbe.httpGetExtra | trim | nindent 14 }}{{ end }}
+            {{- end }}
+            {{- if $.Values.livenessProbe.exec }}
+            exec: {{- toYaml $.Values.livenessProbe.exec | nindent 14 }}
+            {{- end }}
             initialDelaySeconds: {{ $.Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ $.Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ $.Values.livenessProbe.timeoutSeconds }}
@@ -310,10 +320,15 @@ spec:
           {{- end }}
           {{- if $.Values.readinessProbe.enabled }}
           readinessProbe:
+            {{- if $.Values.readinessProbe.httpGetEnabled }}
             httpGet:
               path: {{ $.Values.readinessProbe.path }}
               port: {{ $.Values.readinessProbe.port }}
               {{- if $.Values.readinessProbe.httpGetExtra }}{{ toYaml $.Values.readinessProbe.httpGetExtra | trim | nindent 14 }}{{ end }}
+            {{- end }}
+            {{- if $.Values.readinessProbe.exec }}
+            exec: {{- toYaml $.Values.readinessProbe.exec | nindent 14 }}
+            {{- end }}
             initialDelaySeconds: {{ $.Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ $.Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ $.Values.readinessProbe.timeoutSeconds }}

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -274,6 +274,7 @@ readinessProbe:
   timeoutSeconds: 3
   successThreshold: 1
   failureThreshold: 3
+  httpGetEnabled: true
   httpGetExtra: {}
 
 livenessProbe:
@@ -285,6 +286,7 @@ livenessProbe:
   timeoutSeconds: 3
   successThreshold: 1
   failureThreshold: 3
+  httpGetEnabled: true
   httpGetExtra: {}
 
 startupProbe:
@@ -296,5 +298,6 @@ startupProbe:
   timeoutSeconds: 1
   successThreshold: 1
   failureThreshold: 120
+  httpGetEnabled: true
   httpGetExtra: {}
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?

The `httpGet` probe instructions allows the configuration of custom headers. However, it doesn't support secret access. Hence configuring a secret base64 header to probe secured endpoints is unsupported. The header would be visible in the pod definition as base64.

This changes enables the use of `exec` instruction on the probes which do have access to environment variables of the deployment container.

* Introduces the ability to opt-out the `httpGet` instructions on all probes. 
* Support for `exec` configuration on the probes.
---

### How the changes have been QAed?

The changes can be observed using the following helm command with the following values:

```sh
helm template kestra . -s templates/deployment.yaml --values temp-values.yaml
```

```yaml
startupProbe:
  httpGetEnabled: false
  exec:
    command:
    - bash
    - -c
    - 'curl --fail http://localhost/v1/health --header "Authorization: Basic \${KESTRA_SECURITY_BASIC_BASE64}"'
livenessProbe:
  httpGetEnabled: false
  exec:
    command:
    - bash
    - -c
    - 'curl --fail http://localhost/v1/health --header "Authorization: Basic \${KESTRA_SECURITY_BASIC_BASE64}"'
readinessProbe:
  httpGetEnabled: false
  exec:
    command:
    - bash
    - -c
    - 'curl --fail http://localhost/v1/health --header "Authorization: Basic \${KESTRA_SECURITY_BASIC_BASE64}"'
```

Resulting output:

```sh
...
          startupProbe:
            exec:
              command:
              - bash
              - -c
              - 'curl --fail http://localhost/v1/health --header "Authorization: Basic \${KESTRA_SECURITY_BASIC_BASE64}"'
            ...
          livenessProbe:
            exec:
              command:
              - bash
              - -c
              - 'curl --fail http://localhost/v1/health --header "Authorization: Basic \${KESTRA_SECURITY_BASIC_BASE64}"'
            ...
          readinessProbe:
            exec:
              command:
              - bash
              - -c
              - 'curl --fail http://localhost/v1/health --header "Authorization: Basic \${KESTRA_SECURITY_BASIC_BASE64}"'
            ...
```
