### PR TITLE
Include helm release namespace in port-forwarding instructions

### DIFF
--- a/charts/kestra/templates/NOTES.txt
+++ b/charts/kestra/templates/NOTES.txt
@@ -17,5 +17,5 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kestra.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component={{ ternary "webserver" "standalone" (.Values.deployments.webserver.enabled) }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:8080
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:8080
 {{- end }}


### PR DESCRIPTION
### What changes are being made and why?
When installing the kestra helm chart in a non-default namespace, the current instructions generated by the helm chart are missing the namespace, which leads to not finding the pod for port-forwarding.

---

### How the changes have been QAed?
Install the helm chart in a non-default namespace
```
helm install kestra kestra/kestra --namespace=other
```
The instructions should properly show:
```
kubectl port-forward --namespace other $POD_NAME 8080:8080
```
