### PR TITLE
feat: Add user-defined deployment labels to deployment's pod template

### DIFF
--- a/charts/kestra/templates/_helpers.tpl
+++ b/charts/kestra/templates/_helpers.tpl
@@ -196,6 +196,9 @@ spec:
     metadata:
       labels:
         {{- include "kestra.selectorsLabels" $merged | nindent 8 }}
+        {{- with $deployment.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
 
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") $ | sha256sum }}


### PR DESCRIPTION

### What changes are being made and why?

This PR adds the user-defined deployment labels to the pod template. This ensures that the labels defined in the deployment configuration are also applied to the pods.

### Example:
- #### Values.yaml:
```
deployments:
  webserver:
    enabled: true
    replicaCount: 1
    labels:
      my-label: "my-value"
```
- #### Deployment labels:
```
Labels:
  app.kubernetes.io/component=indexer
  app.kubernetes.io/instance=kestra
  app.kubernetes.io/managed-by=Helm
  app.kubernetes.io/name=kestra
  app.kubernetes.io/version=0.19.0
  helm.sh/chart=kestra-0.19.0
  my-label=my-value
```
- #### Webserver pod labels:
```
Labels:
  app.kubernetes.io/component=indexer
  app.kubernetes.io/instance=kestra
  app.kubernetes.io/name=kestra
  pod-template-hash=595cbc6d75
  my-label=my-value
```
This improvement builds upon my previous [PR #39](https://github.com/kestra-io/helm-charts/pull/39) and is expected to resolve the issue mentioned in [Issue #58](https://github.com/kestra-io/helm-charts/issues/58).
