### PR TITLE
fix: Use micronaut healthcheck path for liveness and readiness probes

### DIFF
--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -306,7 +306,7 @@ securityContext:
 ### ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 readinessProbe:
   enabled: true
-  path: /health
+  path: /health/readiness
   port: management
   initialDelaySeconds: 0
   periodSeconds: 5
@@ -318,7 +318,7 @@ readinessProbe:
 
 livenessProbe:
   enabled: true
-  path: /health
+  path: /health/liveness
   port: management
   initialDelaySeconds: 0
   periodSeconds: 5


### PR DESCRIPTION
### What changes are being made and why?
We recently experienced unintended Kestra pod restarts in our Kubernetes cluster. After analysis we discovered that this was due to a misconfigured liveness probe in the Helm chart. The probe was pointing to `/health`, which depends on external components of the pod. This caused the pod to be restarted by Kubernetes when an external component was unavailable.

To resolve this, we updated the value file to configure the liveness and readiness probes to use the correct Micronaut health paths:
- **Liveness probe** now points to `/health/liveness`
- **Readiness probe** now points to `/health/readiness`

This ensures that the probes accurately reflect the health of the java application itself.

---

This will resolve issue https://github.com/kestra-io/helm-charts/issues/20