### PR TITLE
Helm chart update to 0.20.6

### DIFF
--- a/charts/kestra/Chart.yaml
+++ b/charts/kestra/Chart.yaml
@@ -1,10 +1,9 @@
 apiVersion: v2
 name: kestra
-
 description: Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 home: https://kestra.io
-version: 0.20.4
-appVersion: "v0.20.4"
+version: 0.20.6
+appVersion: "v0.20.6"
 keywords:
   - orchestrator
   - scheduler
@@ -15,9 +14,7 @@ sources:
 maintainers:
   - name: tchiotludo
     email: tchiot.ludo@gmail.com
-
 type: application
-
 annotations:
   artifacthub.io/links: |
     - name: Documentation
@@ -41,7 +38,6 @@ annotations:
       url: https://raw.githubusercontent.com/kestra-io/kestra.io/main/public/docs/user-interface-guide/10-Logs.png
     - title: Documentation
       url: https://raw.githubusercontent.com/kestra-io/kestra.io/main/public/docs/user-interface-guide/12-Documentations-Plugins-Plugin.png
-
 dependencies:
   - name: elasticsearch
     version: ^8.5.1
@@ -59,4 +55,3 @@ dependencies:
     condition: postgresql.enabled
     repository: https://charts.bitnami.com/bitnami
     version: ^15.5.31
-


### PR DESCRIPTION
Helm Chart update to new version:
- In `charts/kestra/Chart.yaml` new `version` is 0.20.6
- In `charts/kestra/Chart.yaml` new `appVersion` is v0.20.6
- Auto-generated by [Action URL][1]

[1]: https://github.com/kestra-io/helm-charts/actions/runs/12279049729