### PR TITLE
Helm chart update from 0.21.4 to 0.21.5

### DIFF
--- a/charts/kestra/Chart.yaml
+++ b/charts/kestra/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kestra
 description: Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 home: https://kestra.io
-version: 0.21.4
-appVersion: "v0.21.4"
+version: 0.21.5
+appVersion: "v0.21.5"
 keywords:
   - orchestrator
   - scheduler


### PR DESCRIPTION
Helm Chart update to new version:
- In `charts/kestra/Chart.yaml` new `version` is 0.21.5
- In `charts/kestra/Chart.yaml` new `appVersion` is v0.21.5
- Auto-generated by [Action URL][1]

[1]: https://github.com/kestra-io/helm-charts/actions/runs/13656883414