### PR TITLE
chore(): add extraPorts

### DIFF
--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -279,6 +279,10 @@ extraEnv: []
 
 extraContainers: []
 
+# extraPorts:
+# - name: jmxremote
+#   containerPort: 8686
+#   protocol: TCP
 extraPorts: []
 
 # https://kestra.io/docs/administrator-guide/configuration/others#kestravariablesenv-vars-prefix

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -279,10 +279,7 @@ extraEnv: []
 
 extraContainers: []
 
-extraPorts:
-- name: jmxremote
-  containerPort: 8686
-  protocol: TCP
+extraPorts: []
 
 # https://kestra.io/docs/administrator-guide/configuration/others#kestravariablesenv-vars-prefix
 extraConfigMapEnvFrom:

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -279,11 +279,12 @@ extraEnv: []
 
 extraContainers: []
 
+# You can setup extra ports
+extraPorts: []
 # extraPorts:
 # - name: jmxremote
 #   containerPort: 8686
 #   protocol: TCP
-extraPorts: []
 
 # https://kestra.io/docs/administrator-guide/configuration/others#kestravariablesenv-vars-prefix
 extraConfigMapEnvFrom:


### PR DESCRIPTION
The goal is have extraPorts capabilities, like extraVolumes, extraContainers, etc. The data in extraPorts follow the way you add a port in kubernetes into a deployment.
