### PR TITLE
Helm chart update from 0.22.13 to 0.23.0-rc4-SNAPSHOT

### DIFF
--- a/charts/kestra/Chart.yaml
+++ b/charts/kestra/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kestra
 description: Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 home: https://kestra.io
-version: 0.22.13
-appVersion: "v0.22.13"
+version: 0.23.0-rc4-SNAPSHOT
+appVersion: "v0.23.0-rc4-SNAPSHOT"
 keywords:
   - orchestrator
   - scheduler


### PR DESCRIPTION
Helm Chart update to new version:
- In `charts/kestra/Chart.yaml` new `version` is 0.23.0-rc4-SNAPSHOT
- In `charts/kestra/Chart.yaml` new `appVersion` is v0.23.0-rc4-SNAPSHOT
- Auto-generated by [Action URL][1]

[1]: https://github.com/kestra-io/helm-charts/actions/runs/15611839555