### PR TITLE
Helm chart update from 1.0.4 to 1.0.5

### DIFF
--- a/charts/kestra/Chart.yaml
+++ b/charts/kestra/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
-version: "1.0.4"
-appVersion: "v1.0.1"
+version: "1.0.5"
+appVersion: "v1.0.5"
 name: kestra
 description: Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 home: https://kestra.io


### PR DESCRIPTION
Helm Chart update to new version:
- In `charts/kestra/Chart.yaml` new `version` is 1.0.5
- In `charts/kestra/Chart.yaml` new `appVersion` is v1.0.5
- Auto-generated by [Action URL][1]

[1]: https://github.com/kestra-io/helm-charts/actions/runs/18379726306