### PR TITLE
chore(kestra-starter)/update-dependency-to-1.0.7

### DIFF
--- a/charts/kestra-starter/Chart.yaml
+++ b/charts/kestra-starter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 version: "1.0.4"
-appVersion: "v1.0.6"
+appVersion: "v1.0.7"
 name: kestra-starter
 description: Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 home: https://kestra.io
@@ -43,4 +43,4 @@ dependencies:
     version: "5.4.0"
   - name: kestra
     repository: https://helm.kestra.io/
-    version: "1.0.6"
+    version: "1.0.7"

--- a/charts/kestra-starter/README.md
+++ b/charts/kestra-starter/README.md
@@ -26,7 +26,7 @@
 
 # kestra-starter
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: v1.0.6](https://img.shields.io/badge/AppVersion-v1.0.6-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: v1.0.7](https://img.shields.io/badge/AppVersion-v1.0.7-informational?style=flat-square)
 
 Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 
@@ -47,7 +47,7 @@ $ helm install my-kestra-starter kestra/kestra-starter --version 1.0.4
 |------------|------|---------|
 | https://charts.min.io/ | minio | 5.4.0 |
 | https://groundhog2k.github.io/helm-charts/ | postgres | 1.5.7 |
-| https://helm.kestra.io/ | kestra | 1.0.6 |
+| https://helm.kestra.io/ | kestra | 1.0.7 |
 
 ## Values
 

--- a/charts/kestra/Chart.yaml
+++ b/charts/kestra/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
-version: "1.0.6"
-appVersion: "v1.0.6"
+version: "1.0.7"
+appVersion: "v1.0.7"
 name: kestra
 description: Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 home: https://kestra.io

--- a/charts/kestra/README.md
+++ b/charts/kestra/README.md
@@ -26,7 +26,7 @@
 
 # kestra
 
-![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![AppVersion: v1.0.6](https://img.shields.io/badge/AppVersion-v1.0.6-informational?style=flat-square)
+![Version: 1.0.7](https://img.shields.io/badge/Version-1.0.7-informational?style=flat-square) ![AppVersion: v1.0.7](https://img.shields.io/badge/AppVersion-v1.0.7-informational?style=flat-square)
 
 Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 
@@ -38,7 +38,7 @@ To install the chart with the release name `my-kestra`:
 
 ```console
 $ helm repo add kestra https://helm.kestra.io/
-$ helm install my-kestra kestra/kestra --version 1.0.6
+$ helm install my-kestra kestra/kestra --version 1.0.7
 ```
 
 ## Migration from 0.x.x to 1.0.0


### PR DESCRIPTION
This pull request updates`kestra-starter` Helm charts dependency to kestra helm chart to version 1.0.7. The changes ensure that documentation and dependencies are consistent with the new release, making it easier for users to install and use the latest version.

Version updates:

* Updated `version` and `appVersion` to `1.0.7` in `charts/kestra/Chart.yaml` and `charts/kestra-starter/Chart.yaml` to reflect the new release. [[1]](diffhunk://#diff-939c513b0b48335ca56873ce136b998d1ca98facccadc13e4d2679512f2ca627L3-R4) [[2]](diffhunk://#diff-fe24f8804e1232db21190ca81fa51a16dd813e549b599c96164c0d477f1d752fL4-R4)

Documentation updates:

* Updated version badges and installation instructions in `charts/kestra/README.md` and `charts/kestra-starter/README.md` to reference `1.0.7`. [[1]](diffhunk://#diff-aa46d7cbbf996fff820def37732c8efa9387d2112689ba7bf744a75fb3735dcfL29-R29) [[2]](diffhunk://#diff-aa46d7cbbf996fff820def37732c8efa9387d2112689ba7bf744a75fb3735dcfL41-R41) [[3]](diffhunk://#diff-1923d19d907254e29dffea4e7d1a29426e200b15ba8aa092333c36628e1eea59L29-R29) [[4]](diffhunk://#diff-1923d19d907254e29dffea4e7d1a29426e200b15ba8aa092333c36628e1eea59L50-R50)

Dependency updates:

* Updated the `kestra` chart dependency in `charts/kestra-starter/Chart.yaml` to version `1.0.7`.