### PR TITLE
feat(gha)/use-app-version-for-branch-creation

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -44,22 +44,32 @@ jobs:
           echo "Detected app version: ${CURRENT_APP_VERSION}"
 
       - name: Skip if incoming version is not newer
-        if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
+        id: version-check
         run: |
           NEW_APP_VER="${CLIENT_PAYLOAD_NEW_VERSION:-${INPUTS_NEW_VERSION}}"
+
           if [ -z "${NEW_APP_VER}" ]; then
-            echo "No new version provided — skipping."
+            echo "No new version provided — skipping workflow."
+            echo "SKIP_HELM_BUMP=true" >> $GITHUB_ENV
             exit 0
           fi
-          echo "Comparing current appVersion (${CURRENT_APP_VERSION}) with incoming version (${NEW_APP_VER})"
-          if [ "$(printf '%s\n' "${CURRENT_APP_VERSION#v}" "${NEW_APP_VER#v}" | sort -V | tail -n1)" != "${NEW_APP_VER#v}" ]; then
+
+          echo "Comparing current appVersion ${CURRENT_APP_VERSION} with incoming version ${NEW_APP_VER}"
+
+          CUR="${CURRENT_APP_VERSION#v}"
+          NEW="${NEW_APP_VER#v}"
+          HIGHEST=$(printf '%s\n' "$CUR" "$NEW" | sort -V | tail -n1)
+
+          if [ "$HIGHEST" != "$NEW" ]; then
             echo "Incoming version is not newer — skipping Helm chart bump."
-            exit 0
+            echo "SKIP_HELM_BUMP=true" >> $GITHUB_ENV
           else
             echo "New version is greater — continuing with Helm chart update."
+            echo "SKIP_HELM_BUMP=false" >> $GITHUB_ENV
           fi
 
       - name: Compute next patch version
+        if: ${{ env.SKIP_HELM_BUMP != 'true' }}
         id: compute-next
         run: |
           IFS='.' read -r MAJOR MINOR PATCH <<< "${LATEST_VERSION}"
@@ -69,6 +79,7 @@ jobs:
           echo "Computed next chart version: ${LATEST_VERSION} -> ${NEXT_CHART_VERSION}"
 
       - name: Update Chart.yaml
+        if: ${{ env.SKIP_HELM_BUMP != 'true' }}
         id: update-chart
         run: |
           set -e
@@ -103,21 +114,24 @@ jobs:
           echo "COMMIT_MSG=${COMMIT_MSG}" >> $GITHUB_ENV
 
       - name: Regenerate Helm docs
+        if: ${{ env.SKIP_HELM_BUMP != 'true' }}
         uses: losisin/helm-docs-github-action@v1
         with:
           git-push: false
 
       - name: Commit changes
+        if: ${{ env.SKIP_HELM_BUMP != 'true' }}
         run: |
           git add "${CHART_FILE}" charts/kestra/README.md
           git commit -m "${COMMIT_MSG}" || echo "No changes to commit"
 
       - name: Create Pull Request
-        if: ${{ env.NEXT_CHART_VERSION != '' }}
+        if: ${{ env.SKIP_HELM_BUMP != 'true' && env.NEXT_CHART_VERSION != '' }}
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ env.HELM_BRANCH_MERGE }}${{ env.NEXT_CHART_VERSION }}
+          branch: ${{ env.HELM_BRANCH_MERGE }}${{ env.COMPUTED_APP_VERSION }}
+
           delete-branch: true
           title: "Helm chart update: ${{ env.LATEST_VERSION }} → ${{ env.NEXT_CHART_VERSION }}"
           body: |


### PR DESCRIPTION
This pull request improves the `bump-version.yml` GitHub workflow by adding a more robust mechanism to skip Helm chart bumps when the incoming version is not newer. It introduces an environment variable (`SKIP_HELM_BUMP`) to control conditional execution of subsequent workflow steps, ensuring that unnecessary operations are not performed when a version bump is not required (backports).

**Conditional Helm bump logic:**

* Added logic to set the `SKIP_HELM_BUMP` environment variable when no new version is provided or the incoming version is not newer, allowing downstream steps to check this variable and skip execution accordingly.

**Conditional execution of workflow steps:**

* Updated the `Compute next patch version`, `Update Chart.yaml`, `Regenerate Helm docs`, and `Commit changes` steps to run only if `SKIP_HELM_BUMP` is not set to `'true'`, preventing unnecessary processing. [[1]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392R82) [[2]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392R117-R134)

**Pull request creation improvements:**

* Modified the pull request creation step to also check `SKIP_HELM_BUMP`, and updated the branch name to use the computed application version instead of the next chart version for consistency.