### PR TITLE
feat(tests)/add-test-to-check-tag-in-bump-release

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -43,6 +43,19 @@ jobs:
           echo "Detected chart version: ${LATEST_VERSION}"
           echo "Detected app version: ${CURRENT_APP_VERSION}"
 
+      - name: Check if target image exists on Docker Hub
+        id: check_image
+        run: |
+          NEW_APP_VER="${CLIENT_PAYLOAD_NEW_VERSION:-${INPUTS_NEW_VERSION}}"
+          IMAGE_NAME="kestra/kestra"
+          echo "Checking if image ${IMAGE_NAME}:${NEW_APP_VER} exists on Docker Hub..."
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/tags/${NEW_APP_VER}/")
+          if [ "$STATUS_CODE" -ne 200 ]; then
+            echo "Docker image ${IMAGE_NAME}:${NEW_APP_VER} does not exist on Docker Hub."
+            exit 1
+          else
+            echo "Docker image ${IMAGE_NAME}:${NEW_APP_VER} exists on Docker Hub."
+          fi
       - name: Skip if incoming version is not newer
         id: version-check
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,6 @@ on:
       - master
     paths-ignore:
       - '.github/**'
-  pull_request:
-    branches:
-      - "**"
-
 jobs:
   build:
     name: Helm Publish


### PR DESCRIPTION
This pull request adds a validation step to the `.github/workflows/bump-version.yml` workflow to ensure that a target Docker image exists on Docker Hub before proceeding with the version bump. This helps prevent version bumps when the corresponding Docker image is missing.

Docker image existence validation:

* Added a new step to check if the Docker image `kestra/kestra` with the target version exists on Docker Hub, and fail the workflow if it does not.