### PR TITLE
feat(bump)/exit-if-version-not-correct

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -63,8 +63,7 @@ jobs:
 
           if [ -z "${NEW_APP_VER}" ]; then
             echo "No new version provided — skipping workflow."
-            echo "SKIP_HELM_BUMP=true" >> $GITHUB_ENV
-            exit 0
+            exit 1
           fi
 
           echo "Comparing current appVersion ${CURRENT_APP_VERSION} with incoming version ${NEW_APP_VER}"
@@ -75,14 +74,12 @@ jobs:
 
           if [ "$HIGHEST" != "$NEW" ]; then
             echo "Incoming version is not newer — skipping Helm chart bump."
-            echo "SKIP_HELM_BUMP=true" >> $GITHUB_ENV
+            exit 1
           else
             echo "New version is greater — continuing with Helm chart update."
-            echo "SKIP_HELM_BUMP=false" >> $GITHUB_ENV
           fi
 
       - name: Compute next patch version
-        if: ${{ env.SKIP_HELM_BUMP != 'true' }}
         id: compute-next
         run: |
           IFS='.' read -r MAJOR MINOR PATCH <<< "${LATEST_VERSION}"
@@ -92,7 +89,6 @@ jobs:
           echo "Computed next chart version: ${LATEST_VERSION} -> ${NEXT_CHART_VERSION}"
 
       - name: Update Chart.yaml
-        if: ${{ env.SKIP_HELM_BUMP != 'true' }}
         id: update-chart
         run: |
           set -e
@@ -127,19 +123,17 @@ jobs:
           echo "COMMIT_MSG=${COMMIT_MSG}" >> $GITHUB_ENV
 
       - name: Regenerate Helm docs
-        if: ${{ env.SKIP_HELM_BUMP != 'true' }}
         uses: losisin/helm-docs-github-action@v1
         with:
           git-push: false
 
       - name: Commit changes
-        if: ${{ env.SKIP_HELM_BUMP != 'true' }}
         run: |
           git add "${CHART_FILE}" charts/kestra/README.md
           git commit -m "${COMMIT_MSG}" || echo "No changes to commit"
 
       - name: Create Pull Request
-        if: ${{ env.SKIP_HELM_BUMP != 'true' && env.NEXT_CHART_VERSION != '' }}
+        if: ${{ env.NEXT_CHART_VERSION != '' }}
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the workflow logic in `.github/workflows/bump-version.yml` to simplify and clarify how version bumps are handled. The main change is the removal of the `SKIP_HELM_BUMP` environment variable, with early exits now used to stop the workflow when a new version is not provided or is not newer than the current version. This streamlines the workflow and makes the control flow easier to follow.

Workflow logic simplification:

* Removed the use of the `SKIP_HELM_BUMP` environment variable and replaced conditional steps with early `exit 1` statements when no new version is provided or the incoming version is not newer. (`.github/workflows/bump-version.yml`) [[1]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392L66-R66) [[2]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392L78-L85)
* Removed conditional execution (`if: ${{ env.SKIP_HELM_BUMP != 'true' }}`) from subsequent workflow steps, allowing them to run only when appropriate based on earlier exits. (`.github/workflows/bump-version.yml`) [[1]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392L95) [[2]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392L130-R136)
* Updated the pull request creation step to depend solely on `env.NEXT_CHART_VERSION != ''` instead of also checking `SKIP_HELM_BUMP`. (`.github/workflows/bump-version.yml`)