### PR TITLE
chore(workflow)/check-tag-after-comparing-version-with-latest

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -43,19 +43,6 @@ jobs:
           echo "Detected chart version: ${LATEST_VERSION}"
           echo "Detected app version: ${CURRENT_APP_VERSION}"
 
-      - name: Check if target image exists on Docker Hub
-        id: check_image
-        run: |
-          NEW_APP_VER="${CLIENT_PAYLOAD_NEW_VERSION:-${INPUTS_NEW_VERSION}}"
-          IMAGE_NAME="kestra/kestra"
-          echo "Checking if image ${IMAGE_NAME}:${NEW_APP_VER} exists on Docker Hub..."
-          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/tags/${NEW_APP_VER}/")
-          if [ "$STATUS_CODE" -ne 200 ]; then
-            echo "Docker image ${IMAGE_NAME}:${NEW_APP_VER} does not exist on Docker Hub."
-            exit 1
-          else
-            echo "Docker image ${IMAGE_NAME}:${NEW_APP_VER} exists on Docker Hub."
-          fi
       - name: Skip if incoming version is not newer
         id: version-check
         run: |
@@ -77,6 +64,20 @@ jobs:
             exit 1
           else
             echo "New version is greater — continuing with Helm chart update."
+          fi
+
+      - name: Check if target image exists on Docker Hub
+        id: check_image
+        run: |
+          NEW_APP_VER="${CLIENT_PAYLOAD_NEW_VERSION:-${INPUTS_NEW_VERSION}}"
+          IMAGE_NAME="kestra/kestra"
+          echo "Checking if image ${IMAGE_NAME}:${NEW_APP_VER} exists on Docker Hub..."
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/tags/${NEW_APP_VER}/")
+          if [ "$STATUS_CODE" -ne 200 ]; then
+            echo "Docker image ${IMAGE_NAME}:${NEW_APP_VER} does not exist on Docker Hub."
+            exit 1
+          else
+            echo "Docker image ${IMAGE_NAME}:${NEW_APP_VER} exists on Docker Hub."
           fi
 
       - name: Compute next patch version


### PR DESCRIPTION
This pull request reorganizes the steps in the `.github/workflows/bump-version.yml` workflow to improve the order of version and image validation checks. The main change is moving the Docker image existence check to occur AFTER verifying that the incoming version is newer, ensuring that unnecessary image checks are avoided for non-newer versions.

Workflow step reordering:

* Moved the "Check if target image exists on Docker Hub" step to run after the version comparison, so the image existence is only checked if the incoming version is newer. [[1]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392L46-L58) [[2]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392R69-R82)