### PR TITLE
chore(helm-starter)/bump-to-version-v1.1.2

### DIFF
--- a/charts/kestra-starter/Chart.yaml
+++ b/charts/kestra-starter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
-version: "1.0.8"
-appVersion: "v1.1.1"
+version: "1.0.9"
+appVersion: "v1.1.2"
 name: kestra-starter
 description: Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 home: https://kestra.io
@@ -43,4 +43,4 @@ dependencies:
     version: "5.4.0"
   - name: kestra
     repository: https://helm.kestra.io/
-    version: "1.0.12"
+    version: "1.0.13"

--- a/charts/kestra-starter/README.md
+++ b/charts/kestra-starter/README.md
@@ -26,7 +26,7 @@
 
 # kestra-starter
 
-![Version: 1.0.8](https://img.shields.io/badge/Version-1.0.8-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
+![Version: 1.0.9](https://img.shields.io/badge/Version-1.0.9-informational?style=flat-square) ![AppVersion: v1.1.2](https://img.shields.io/badge/AppVersion-v1.1.2-informational?style=flat-square)
 
 Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 
@@ -38,7 +38,7 @@ To install the chart with the release name `my-kestra-starter`:
 
 ```console
 $ helm repo add kestra https://helm.kestra.io/
-$ helm install my-kestra-starter kestra/kestra-starter --version 1.0.8
+$ helm install my-kestra-starter kestra/kestra-starter --version 1.0.9
 ```
 
 ## Requirements
@@ -47,7 +47,7 @@ $ helm install my-kestra-starter kestra/kestra-starter --version 1.0.8
 |------------|------|---------|
 | https://charts.min.io/ | minio | 5.4.0 |
 | https://groundhog2k.github.io/helm-charts/ | postgres | 1.5.7 |
-| https://helm.kestra.io/ | kestra | 1.0.12 |
+| https://helm.kestra.io/ | kestra | 1.0.13 |
 
 ## Values
 


### PR DESCRIPTION
This pull request updates the versioning for the `kestra-starter` Helm chart and its dependencies to ensure compatibility with the latest releases. The changes are mainly focused on bumping the chart, application, and dependency versions, and reflecting these updates in the documentation.

Version and dependency updates:

* Updated `version` to `1.0.9` and `appVersion` to `v1.1.2` in `Chart.yaml` to release a new chart version.
* Bumped the `kestra` dependency version from `1.0.12` to `1.0.13` in `Chart.yaml` for improved compatibility.

Documentation updates:

* Updated version badges in `README.md` to reflect the new chart and app versions.
* Changed installation instructions in `README.md` to use the new chart version (`1.0.9`).
* Updated the requirements table in `README.md` to show the new `kestra` dependency version (`1.0.13`).