### PR TITLE
chore: add possibility to disable dind on standalone mode

### DIFF
--- a/charts/kestra/Chart.yaml
+++ b/charts/kestra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 type: application
-version: "1.0.15"
+version: "1.0.16"
 appVersion: "v1.1.4"
 name: kestra
 description: Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.

--- a/charts/kestra/README.md
+++ b/charts/kestra/README.md
@@ -26,7 +26,7 @@
 
 # kestra
 
-![Version: 1.0.15](https://img.shields.io/badge/Version-1.0.15-informational?style=flat-square) ![AppVersion: v1.1.4](https://img.shields.io/badge/AppVersion-v1.1.4-informational?style=flat-square)
+![Version: 1.0.16](https://img.shields.io/badge/Version-1.0.16-informational?style=flat-square) ![AppVersion: v1.1.4](https://img.shields.io/badge/AppVersion-v1.1.4-informational?style=flat-square)
 
 Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 
@@ -38,7 +38,7 @@ To install the chart with the release name `my-kestra`:
 
 ```console
 $ helm repo add kestra https://helm.kestra.io/
-$ helm install my-kestra kestra/kestra --version 1.0.15
+$ helm install my-kestra kestra/kestra --version 1.0.16
 ```
 
 ## Migration from 0.x.x to 1.0.0
@@ -266,6 +266,7 @@ The **workerGroups** follow exactly the same pattern you see in deployments key 
 | deployments.indexer.extraArgs | list | `[]` | Extra arguments to pass to the container. |
 | deployments.scheduler.enabled | bool | `false` | Enable scheduler in distributed mode. |
 | deployments.scheduler.extraArgs | list | `[]` | Extra arguments to pass to the container. |
+| deployments.standalone.dind.enabled | bool | `true` | Enable dind sidecar in standalone deployment. |
 | deployments.standalone.enabled | bool | `true` | Enable standalone Kestra deployment. |
 | deployments.standalone.extraArgs | list | `[]` | Extra arguments to pass to the container. |
 | deployments.standalone.workerThreads | int | `0` | Number of worker threads for standalone deployment ; "0" to auto-configure based on CPU. |

--- a/charts/kestra/templates/deployment.yaml
+++ b/charts/kestra/templates/deployment.yaml
@@ -17,7 +17,7 @@
 {{- if and ($global.dind.enabled) (eq $type "worker") }}
 {{- $dind = true }}
 {{- end }}
-{{- if and ($global.dind.enabled) (eq $type "standalone") }}
+{{- if and ($global.dind.enabled) (eq $type "standalone") ($global.deployments.standalone.dind.enabled) }}
 {{- $dind = true }}
 {{- end }}
 {{- $kind := default $common.kind $content.kind }}

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -206,6 +206,10 @@ deployments:
     # -- Extra arguments to pass to the container.
     # @section -- kestra deployments
     extraArgs: []
+    dind:
+      # -- Enable dind sidecar in standalone deployment.
+      # @section -- kestra deployments
+      enabled: true
   webserver:
     # -- Enable webserver in distributed mode.
     # @section -- kestra deployments


### PR DESCRIPTION
the goal is to have the possibilty to disable the dind on server standalone, and to have a worker with dind, like this:

```yaml
deployments:
  standalone:
    enabled: true
    args: ["--worker-thread=0"]
    dind:
      enabled: false
  worker:
    enabled: true
dind:
  enabled: true
```

* The pod with server standalone will not have the dind, and no worker process runnin.
* Second pod worker with dind