### PR TITLE
chore(kestra-starter)/bump-to-kestra-chart-version-v1.0.19

### DIFF
--- a/charts/kestra-starter/Chart.yaml
+++ b/charts/kestra-starter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
-version: "1.0.12"
-appVersion: "v1.1.5"
+version: "1.0.13"
+appVersion: "v1.1.6"
 name: kestra-starter
 description: Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 home: https://kestra.io
@@ -43,4 +43,4 @@ dependencies:
     version: "5.4.0"
   - name: kestra
     repository: https://helm.kestra.io/
-    version: "1.0.18"
+    version: "1.0.19"

--- a/charts/kestra-starter/README.md
+++ b/charts/kestra-starter/README.md
@@ -26,7 +26,7 @@
 
 # kestra-starter
 
-![Version: 1.0.12](https://img.shields.io/badge/Version-1.0.12-informational?style=flat-square) ![AppVersion: v1.1.5](https://img.shields.io/badge/AppVersion-v1.1.5-informational?style=flat-square)
+![Version: 1.0.13](https://img.shields.io/badge/Version-1.0.13-informational?style=flat-square) ![AppVersion: v1.1.6](https://img.shields.io/badge/AppVersion-v1.1.6-informational?style=flat-square)
 
 Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 
@@ -38,7 +38,7 @@ To install the chart with the release name `my-kestra-starter`:
 
 ```console
 $ helm repo add kestra https://helm.kestra.io/
-$ helm install my-kestra-starter kestra/kestra-starter --version 1.0.12
+$ helm install my-kestra-starter kestra/kestra-starter --version 1.0.13
 ```
 
 ## Requirements
@@ -47,7 +47,7 @@ $ helm install my-kestra-starter kestra/kestra-starter --version 1.0.12
 |------------|------|---------|
 | https://charts.min.io/ | minio | 5.4.0 |
 | https://groundhog2k.github.io/helm-charts/ | postgres | 1.5.7 |
-| https://helm.kestra.io/ | kestra | 1.0.18 |
+| https://helm.kestra.io/ | kestra | 1.0.19 |
 
 ## Values
 


### PR DESCRIPTION
This pull request updates the `kestra-starter` Helm chart and its documentation to reflect new versions for both the chart itself and its main dependency, `kestra`. These changes ensure users get the latest features and fixes when deploying or upgrading.

Version updates:

* Bumped `kestra-starter` chart version to `1.0.13` and `appVersion` to `v1.1.6` in `Chart.yaml` and updated corresponding version badges in `README.md`. [[1]](diffhunk://#diff-fe24f8804e1232db21190ca81fa51a16dd813e549b599c96164c0d477f1d752fL3-R4) [[2]](diffhunk://#diff-1923d19d907254e29dffea4e7d1a29426e200b15ba8aa092333c36628e1eea59L29-R29)
* Updated installation instructions and dependency table in `README.md` to use the new chart version (`1.0.13`).
* Updated the `kestra` dependency version from `1.0.18` to `1.0.19` in both `Chart.yaml` and `README.md` requirements table. [[1]](diffhunk://#diff-fe24f8804e1232db21190ca81fa51a16dd813e549b599c96164c0d477f1d752fL46-R46) [[2]](diffhunk://#diff-1923d19d907254e29dffea4e7d1a29426e200b15ba8aa092333c36628e1eea59L50-R50)