### PR TITLE
chore(kestra-starter)/bump-to-kestra-chart-version-v1.0.24

### DIFF
--- a/charts/kestra-starter/Chart.yaml
+++ b/charts/kestra-starter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
-version: "1.0.15"
-appVersion: "v1.1.9"
+version: "1.0.16"
+appVersion: "v1.1.10"
 name: kestra-starter
 description: Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 home: https://kestra.io
@@ -43,4 +43,4 @@ dependencies:
     version: "5.4.0"
   - name: kestra
     repository: https://helm.kestra.io/
-    version: "1.0.22"
+    version: "1.0.24"

--- a/charts/kestra-starter/README.md
+++ b/charts/kestra-starter/README.md
@@ -26,7 +26,7 @@
 
 # kestra-starter
 
-![Version: 1.0.15](https://img.shields.io/badge/Version-1.0.15-informational?style=flat-square) ![AppVersion: v1.1.9](https://img.shields.io/badge/AppVersion-v1.1.9-informational?style=flat-square)
+![Version: 1.0.16](https://img.shields.io/badge/Version-1.0.16-informational?style=flat-square) ![AppVersion: v1.1.10](https://img.shields.io/badge/AppVersion-v1.1.10-informational?style=flat-square)
 
 Infinitely scalable, event-driven, language-agnostic orchestration and scheduling platform to manage millions of workflows declaratively in code.
 
@@ -38,7 +38,7 @@ To install the chart with the release name `my-kestra-starter`:
 
 ```console
 $ helm repo add kestra https://helm.kestra.io/
-$ helm install my-kestra-starter kestra/kestra-starter --version 1.0.15
+$ helm install my-kestra-starter kestra/kestra-starter --version 1.0.16
 ```
 
 ## Requirements
@@ -47,7 +47,7 @@ $ helm install my-kestra-starter kestra/kestra-starter --version 1.0.15
 |------------|------|---------|
 | https://charts.min.io/ | minio | 5.4.0 |
 | https://groundhog2k.github.io/helm-charts/ | postgres | 1.5.7 |
-| https://helm.kestra.io/ | kestra | 1.0.22 |
+| https://helm.kestra.io/ | kestra | 1.0.24 |
 
 ## Values
 


### PR DESCRIPTION
This pull request updates the `kestra-starter` Helm chart and its documentation to use the latest versions of the application and its dependencies. The main changes are version bumps for both the chart and the underlying `kestra` dependency.

**Version updates:**

* Bumped the `kestra-starter` chart version to `1.0.16` and the application version to `v1.1.10` in both `Chart.yaml` and the version badges in `README.md`. [[1]](diffhunk://#diff-fe24f8804e1232db21190ca81fa51a16dd813e549b599c96164c0d477f1d752fL3-R4) [[2]](diffhunk://#diff-1923d19d907254e29dffea4e7d1a29426e200b15ba8aa092333c36628e1eea59L29-R29)
* Updated the `kestra` Helm dependency from version `1.0.22` to `1.0.24` in `Chart.yaml` and reflected this change in the dependency table in `README.md`. [[1]](diffhunk://#diff-fe24f8804e1232db21190ca81fa51a16dd813e549b599c96164c0d477f1d752fL46-R46) [[2]](diffhunk://#diff-1923d19d907254e29dffea4e7d1a29426e200b15ba8aa092333c36628e1eea59L50-R50)

**Documentation updates:**

* Updated the installation instructions in `README.md` to reference the new chart version (`1.0.16`).