### PR TITLE
fix(helm-publish)/fix-the-releaser-when-it-compares-versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,19 @@ jobs:
           cp -R charts/kestra .cr-charts/
           cp -R charts/kestra-operator .cr-charts/
 
+      - name: Workaround for manual tagging
+        run: |
+          echo "Current tag is ${{ github.ref_name }}"
+          echo "Deleting current tag locally so 'cr' compares HEAD against the previous tag..."
+          git tag -d ${{ github.ref_name }}
+
       - name: Publish (upload + index)
         uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: .cr-charts
           pages_branch: gh-pages
           packages_with_index: true
+          skip_existing: true
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This pull request updates the Helm chart release workflow to improve handling of manual tagging and publishing. The key changes focus on ensuring correct tag comparison and preventing errors when publishing charts that may already exist.

Workflow improvements for Helm chart releases:

* Added a step to delete the current git tag locally before publishing, which works around issues with manual tagging by ensuring the `cr` tool compares the current HEAD against the previous tag.
* Updated the Helm chart releaser action configuration to skip publishing charts that already exist, preventing errors during the release process.