### PR TITLE
feat(helm release)/add slack message upon pr creation

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,6 +19,9 @@ env:
   CI_COMMIT_AUTHOR: bump-version-wf
   CI_COMMIT_EMAIL: actions@github.com
 
+  # Slack
+  SLACK_CHANNEL_ID: C0AJDEN8AV7 # channel _int_devops-build
+
   # Branch naming
   HELM_BRANCH_MERGE: "feat-helm/update-to-"
 
@@ -226,7 +229,7 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            channel: C0AJDEN8AV7
+            channel: ${{ env.SLACK_CHANNEL_ID }}
             username: GitHub Actions
             icon_emoji: ":github-actions:"
             text: |


### PR DESCRIPTION
This pull request updates the `bump-version.yml` GitHub Actions workflow to improve automation and communication around Helm chart version bumps. The main enhancements include integrating Slack notifications for pull request creation and assigning reviewers automatically.

Integration with Slack:

* Added Slack channel and webhook environment variables (`SLACK_CHANNEL_ID`, `SLACK_WEBHOOK_URL`) to enable notifications. [[1]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392R22-R24) [[2]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392R39-R40)
* Introduced a Slack notification step that sends a message to the designated channel when a Helm chart bump pull request is created.

Pull request automation improvements:

* Configured the pull request creation step to automatically assign the `kestra-io/devops` team as reviewers.
* Added an `id` to the pull request step for referencing output variables in later steps.