### PR TITLE
fix(ci): resolve kestra-starter dep from local chart in tests

### DIFF
--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -85,6 +85,12 @@ jobs:
         uses: asdf-vm/actions/install@v4
       - name: Run tests
         run: |
+          # Package local kestra chart and serve as a local Helm repo
+          # so helm dep up resolves it without needing the version published yet
+          helm package charts/kestra --destination /tmp/kestra-pkg/
+          helm repo index /tmp/kestra-pkg/
+          helm repo add local-kestra "file:///tmp/kestra-pkg" --force-update
+          sed -i 's|repository: https://helm.kestra.io/|repository: file:///tmp/kestra-pkg|' charts/kestra-starter/Chart.yaml
           helm dep up charts/kestra-starter/
           helm template charts/kestra-starter --validate=false > output.yaml
           kubeconform -strict -summary output.yaml


### PR DESCRIPTION
## Summary
`tests-kestra-starter` was failing on every version bump because `helm dep up` tried to fetch the new `kestra` chart version from `https://helm.kestra.io/` before it was published. Publishing only happens after merge → tag → `release.yml`. The fix packages the local `kestra` chart into a `file://` Helm repo and patches `kestra-starter/Chart.yaml` at CI time so the dependency resolves locally.

## Changes
- Package local `kestra` chart and serve via `file://` repo before running `helm dep up` in `tests-kestra-starter`

close kestra-io/helm-charts#288